### PR TITLE
AR-1708 Improved method for logging exceptions

### DIFF
--- a/lib/logatron/logatron.rb
+++ b/lib/logatron/logatron.rb
@@ -16,8 +16,10 @@ module Logatron
       @log ||= Logatron::BasicLogger.new
     end
 
-    def log_exception(e, severity)
-      logger.send(severity.downcase, "#{e.class} #{e.message} -> #{configuration.backtrace_cleaner.clean(e.backtrace).join(' -> ')}")
+    def log_exception(e, severity, additional_info={})
+      # 'additional_info' can be a flat hash or anything with '#to_s'
+      message = exception_message(e, additional_info)
+      logger.send(severity.downcase, message)
     end
 
     def level=(level)
@@ -71,6 +73,15 @@ module Logatron
 
     def msg_id=(id)
       Logatron::Contexts.msg_id = id
+    end
+
+    private
+
+    def exception_message(e, additional)
+      info = additional.is_a?(Hash) ? additional.map { |(k, v)| "#{k}=>#{v}"}.join(', ') : additional
+      info_msg = info.nil? || info.empty? ? '' : "; MORE_INFO( #{info} )"
+      backtrace = configuration.backtrace_cleaner.clean(e.backtrace).join(' -> ')
+      "#{e.class} #{e.message}#{info_msg} -> #{backtrace}"
     end
   end
 end

--- a/spec/lib/logatron/logatron_spec.rb
+++ b/spec/lib/logatron/logatron_spec.rb
@@ -1,0 +1,35 @@
+require 'rspec'
+require 'logatron/logatron'
+
+module Logatron
+
+  describe 'log_exception' do
+    let!(:logger) { Logatron::BasicLogger.new }
+    let(:error) { StandardError.new('My message') }
+    before :each do
+      allow(Logatron).to receive(:logger) { logger }
+      allow(error).to receive(:backtrace) { %w(one two three) }
+    end
+    context 'when additional information not provided' do
+      it 'logs error with severity' do
+        msg = 'StandardError My message -> one -> two -> three'
+        expect(logger).to receive(:info).with(msg)
+        Logatron.log_exception(error, Logatron::INFO)
+      end
+    end
+    context 'when additional information is provided as hash' do
+      it 'logs error with severity and hash values' do
+        msg = 'StandardError My message; MORE_INFO( my=>hash, of=>values ) -> one -> two -> three'
+        expect(logger).to receive(:info).with(msg)
+        Logatron.log_exception(error, Logatron::INFO, {my: 'hash', of: 'values'})
+      end
+    end
+    context 'when additional information is provided as a string' do
+      it 'logs error with severity and hash values' do
+        msg = 'StandardError My message; MORE_INFO( my string of values ) -> one -> two -> three'
+        expect(logger).to receive(:info).with(msg)
+        Logatron.log_exception(error, Logatron::INFO, 'my string of values')
+      end
+    end
+  end
+end


### PR DESCRIPTION
[AR-1708]

Additional info can now augment the message when logging exceptions. The additional data can be a hash or a string.
